### PR TITLE
[25] Correct item type labels when creating items or managing inventory

### DIFF
--- a/src/main/resources/templates/admin/client/add-item.html
+++ b/src/main/resources/templates/admin/client/add-item.html
@@ -136,7 +136,9 @@
                    th:value="${client.name}"
                    readonly="readonly" />
 
-            <label for="itemName">Item</label>
+            <label for="itemName">
+                [[${#strings.capitalize(itemType)}]]
+            </label>
             <div class="input-group">
                 <span class="input-group-label"><i class="fa fa-times"></i></span>
                 <input  type="text"

--- a/src/main/resources/templates/admin/item/add-item.html
+++ b/src/main/resources/templates/admin/item/add-item.html
@@ -29,7 +29,7 @@
         </th:block>
         <form th:action="@{''}" th:object="${item}" method="post" autocomplete="off">
             <input type="hidden" th:field="*{itemType}" />
-            <label for="itemName">Item Name</label>
+            <label for="itemName">[[${#strings.capitalizeWords(item.itemType.toString().toLowerCase())}]]</label>
             <input type="text"
                    id="itemName"
                    th:field="*{name}"


### PR DESCRIPTION
Corrects the item type labels to display "Item" or "Currency" selectively instead of Item in all cases.